### PR TITLE
add a WorkerThread class

### DIFF
--- a/protobackend/dispatcher.py
+++ b/protobackend/dispatcher.py
@@ -53,7 +53,9 @@ class Dispatcher:
         Commands.py used a function like console, to call a method named runConsole.
         """
         def f(payload):
-            return self.dispatch({'command': 'run' + cmd_name.title(), 'payload': payload})
+            # convert to camel case
+            cml_cmd = "run" + "".join([wrd.title() for wrd in cmd_name.split('_')])
+            return self.dispatch({'command': cml_cmd, 'payload': payload})
 
         return f
 
@@ -75,3 +77,28 @@ def init_hook(data, cmd, dispatcher):
         dispatcher.active_exercise = ExCls(data)
     
     return data
+
+# Worker thread ---------------------------------------------------------------
+
+import threading
+from queue import Queue, Empty
+class WorkerThread(threading.Thread):
+    def __init__(self, dispatch, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.q_command = Queue()
+        self.q_result = Queue()
+        self.stop_request = threading.Event()
+        self.dispatch = dispatch
+
+    def run(self):
+        while not self.stop_request.is_set():
+            try:
+                cmd = self.q_command.get(True, 0.05)
+                self.q_result.put((cmd, self.dispatch(cmd)))
+                self.q_command.task_done()
+            except Empty:
+                continue
+
+    def join(self, timeout = None):
+        self.stop_request.set()
+        super().join(timeout)

--- a/protobackend/dispatcher.py
+++ b/protobackend/dispatcher.py
@@ -47,15 +47,19 @@ class Dispatcher:
 
         return f
 
-    def _expose_run(self, cmd_name):
+    def _expose_run(self, cmd_name, dispatch = None):
         """For backwards compatibility.
         
         Commands.py used a function like console, to call a method named runConsole.
         """
+
+        dispatch = self.dispatch if dispatch is None else dispatch
+
         def f(payload):
             # convert to camel case
             cml_cmd = "run" + "".join([wrd.title() for wrd in cmd_name.split('_')])
-            return self.dispatch({'command': cml_cmd, 'payload': payload})
+
+            return dispatch({'command': cml_cmd, 'payload': payload})
 
         return f
 
@@ -102,3 +106,4 @@ class WorkerThread(threading.Thread):
     def join(self, timeout = None):
         self.stop_request.set()
         super().join(timeout)
+

--- a/protobackend/exercise.py
+++ b/protobackend/exercise.py
@@ -1,7 +1,7 @@
 class BaseExercise:
     EXERCISE_TYPE = "Exercise"
 
-    def __init__(self, data):
+    def __init__(self, data, worker = None):
         self.dc_pec = data.get("DC_PEC", "")
         self.dc_solution = data.get("DC_SOLUTION", "")
         self.dc_sct = data.get("DC_SCT", "")
@@ -9,6 +9,9 @@ class BaseExercise:
 
         self.student_result = None
         self.solution_result = None
+
+        # optional worker thread for queueing commands
+        self.worker = worker
 
     def runInit(self, data):
         raise Exception("Need to define a custom runInit method")

--- a/protobackend/output.py
+++ b/protobackend/output.py
@@ -17,7 +17,7 @@ class CaptureErrors(object):
         if exc_type is None:
             return
 
-        debug = os.environ.get('SQL_BACKEND_DEBUG')
+        debug = os.environ.get('SQL_BACKEND_DEBUG') or os.environ.get('DC_BACKEND_DEBUG')
         if debug == "True" :
             error_message = Traceback.format_exception(exc_type, exception, traceback)
         elif debug == "raise":
@@ -55,3 +55,13 @@ def safe_dump(f, json_dumper=None):
         return json_dumper(fallback_output)
     return wrapper
 
+def print_output(s):
+    print("\n[1] %s\n\n>>> " % json.dumps(s))
+
+def output_dec(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        s = f(*args, **kwargs)
+        print_output(s)
+        return s
+    return wrapper


### PR DESCRIPTION
need to add unit tests. This will be used to run shellbackend SCTs in sync with normal backend commands (and take the execution of commands in the backend off of the main thread, which was a bit strange to begin with).

note, this corresponds to https://github.com/datacamp/shellbackend/pull/46