### PR TITLE
Combine array of exception traceback strings

### DIFF
--- a/protobackend/output.py
+++ b/protobackend/output.py
@@ -25,7 +25,7 @@ class CaptureErrors(object):
         if debug == "raise":
             raise exception
         elif debug:
-            error_message = Traceback.format_exception(exc_type, exception, traceback)
+            error_message = "".join(Traceback.format_exception(exc_type, exception, traceback))
         else:
             error_message = str(exception)
 


### PR DESCRIPTION
Instead of printing the array

A newline is included in each string in the joined array:
https://docs.python.org/3.6/library/traceback.html#traceback.format_exception