### PR TITLE
Safe dump should dump a list

### DIFF
--- a/protobackend/output.py
+++ b/protobackend/output.py
@@ -54,6 +54,8 @@ def safe_dump(f, json_dumper=None):
         fallback_output = []
         with CaptureErrors(fallback_output):
             output = f(*args, **kwargs)
+            if not isinstance(output, list):
+                output = []
             return json_dumper(output)
 
         return json_dumper(fallback_output)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python
 
+from os import path
 from setuptools import setup
 
+PACKAGE_NAME = "protobackend"
+VERSION="0.2.1"
+
+HERE = path.abspath(path.dirname(__file__))
+README_FILE = path.join(HERE, "README.md")
+
+with open(README_FILE, encoding="utf-8") as fp:
+    README = fp.read()
+
 setup(
-	name='protobackend',
-	version='0.2.1',
-	packages=['protobackend'],
-        description = 'Generic backend',
-        author = 'Michael Chow',
-        author_email = 'michael@datacamp.com',
-        url = 'https://github.com/datacamp/protobackend'
+    name=PACKAGE_NAME,
+    version=VERSION,
+    packages=[PACKAGE_NAME],
+    description="Generic backend",
+    long_description=README,
+    long_description_content_type="text/markdown",
+    author="Michael Chow",
+    author_email="michael@datacamp.com",
+    maintainer="Jeroen Hermans",
+    maintainer_email="content-engineering@datacamp.com",
+    url="https://github.com/datacamp/protobackend",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU Affero General Public License v3",
+        "Operating System :: OS Independent",
+    ],
 )


### PR DESCRIPTION
The output is expected to be a list, this makes it an empty list if it isn't one (e.g. because a function returns nothing/`None`.